### PR TITLE
Avoid injecting template to ADL

### DIFF
--- a/include/xcpp/xmime.hpp
+++ b/include/xcpp/xmime.hpp
@@ -43,7 +43,7 @@ namespace xcpp
 
     // Default implementation of mime_bundle_repr
     template <class T>
-    nl::json mime_bundle_repr(const T& value)
+    nl::json fallback_mime_bundle_repr(const T& value)
     {
         auto bundle = nl::json::object();
         bundle["text/plain"] = cling::printValue(&value);
@@ -52,14 +52,14 @@ namespace xcpp
 
     // Implementation for std::complex.
     template <class T>
-    nl::json mime_bundle_repr(const std::complex<T>& value)
+    nl::json fallback_mime_bundle_repr(const std::complex<T>& value)
     {
         return detail::mime_bundle_repr_via_sstream(value);
     }
 
     // Implementation for long double. This is a workaround for
     // https://github.com/jupyter-xeus/xeus-cling/issues/220
-    inline nl::json mime_bundle_repr(const long double& value)
+    inline nl::json fallback_mime_bundle_repr(const long double& value)
     {
         return detail::mime_bundle_repr_via_sstream(value);
     }


### PR DESCRIPTION
The current default implementation of `mime_bundle_repr` injects a template to the Argument Dependent Lookup. This is very inconvenient because the user may also want to also provide a templated function. Unfortunately this will fall in overload resolution stage because of ambiguity (see https://godbolt.org/z/n9xxE44TW). Therefore (based on https://godbolt.org/z/Gsr1fq6TM), I propose a concept check that test if the user provided her own `mime_bundle_repr` and if so dispatch it to the display data, otherwise, call the fallback implementation.